### PR TITLE
MDate update

### DIFF
--- a/app/src/main/java/dk/mustache/corelibexample/mdate/MdateActivity.kt
+++ b/app/src/main/java/dk/mustache/corelibexample/mdate/MdateActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.widget.TextView
 import dk.mustache.corelib.utils.CaseType
 import dk.mustache.corelib.utils.MDate
-import dk.mustache.corelib.utils.MDateBuilder
 import dk.mustache.corelib.utils.MDateFormat.*
 import dk.mustache.corelibexample.R
 import java.util.*
@@ -28,6 +27,7 @@ class MdateActivity : AppCompatActivity() {
         setupTimeManipulation()
         setupShowDates()
         setupOther()
+        setupConvenienceMethods()
     }
 
     private fun setupDateManipulation() {
@@ -156,6 +156,27 @@ class MdateActivity : AppCompatActivity() {
         val dateuk = MDate.BuilderGb().date(year = 2022, month = 3, day = 1).build()
         val txtDemoEnglish = findViewById<TextView>(R.id.txtDemoEnglish)
         txtDemoEnglish.text = "English/UK Localization:\n" + dateuk.show(PRETTYDATE_LONG)
+    }
+
+    private fun setupConvenienceMethods() {
+        val propdate = createMdate()
+        val txtProperties = findViewById<TextView>(R.id.txtProperties)
+        txtProperties.text = propdate.show(DATE_YEAR) + " " + propdate.show(TIME_SECONDS) +
+                ": Year: ${propdate.year} Mon: ${propdate.month} Day: ${propdate.day} " +
+                "Hour: ${propdate.hour} Min: ${propdate.minute} Sec: ${propdate.second}"
+
+        val dateToRound = createMdate()
+        val roundedDate = dateToRound.roundToDate()
+        val txtRoundtodate = findViewById<TextView>(R.id.txtRoundToDate)
+        txtRoundtodate.text = dateToRound.show(DATE_YEAR) + " " + dateToRound.show(TIME_SECONDS) +
+                " converts to " + roundedDate.show(DATE_YEAR) + " " + roundedDate.show(TIME_SECONDS)
+
+        val compareDate1 = createMdate()
+        val compareDate2 = createMdate()
+        val txtCompareTo = findViewById<TextView>(R.id.txtCompareTo)
+        txtCompareTo.text = compareDate1.show(DATE_YEAR) + " " + compareDate1.show(TIME_SECONDS) +
+                " <= " + compareDate2.show(DATE_YEAR) + " " + compareDate2.show(TIME_SECONDS) + " = " +
+                (compareDate1 <= compareDate2)
     }
 
     private fun createMdate(): MDate {

--- a/app/src/main/res/layout/activity_mdate.xml
+++ b/app/src/main/res/layout/activity_mdate.xml
@@ -145,6 +145,26 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="4dp"/>
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="CONVENIENCE METHODS"
+            android:gravity="center"
+            android:padding="8dp"
+            android:textColor="@color/colorPrimary"
+            android:background="@color/white"/>
+        <TextView android:id="@+id/txtProperties"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"/>
+        <TextView android:id="@+id/txtRoundToDate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"/>
+        <TextView android:id="@+id/txtCompareTo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"/>
     </LinearLayout>
 
 

--- a/corelib/src/main/java/dk/mustache/corelib/utils/MDate.kt
+++ b/corelib/src/main/java/dk/mustache/corelib/utils/MDate.kt
@@ -58,8 +58,6 @@ enum class MDateFormat(val pattern: String) {
     TIME ("HH:mm")
 }
 
-enum class MDatePrettyFormat
-
 /**
  * Convenience class allowing the easy manipulation and string
  * formatting of a java Calendar instance.
@@ -74,7 +72,14 @@ enum class MDatePrettyFormat
  * @property calendar The calendar to encapsulate
  * @property locale The locale to use for formatting
  */
-class MDate(val calendar: Calendar = Calendar.getInstance(), private val locale: Locale) {
+class MDate(val calendar: Calendar = Calendar.getInstance(), private val locale: Locale): Comparable<MDate> {
+
+    val year get() = calendar.get(Calendar.YEAR)
+    val month get() = calendar.get(Calendar.MONTH)+1
+    val day get() = calendar.get(Calendar.DAY_OF_MONTH)
+    val hour get() = calendar.get(Calendar.HOUR_OF_DAY)
+    val minute get() = calendar.get(Calendar.MINUTE)
+    val second get() = calendar.get(Calendar.SECOND)
 
     /**
      * Show date or time according to provided format. Only PrettyDate
@@ -248,6 +253,15 @@ class MDate(val calendar: Calendar = Calendar.getInstance(), private val locale:
         return add(Calendar.SECOND, seconds)
     }
 
+    fun roundToDate(): MDate {
+        val newCal = calendar.clone() as Calendar
+        newCal.set(Calendar.HOUR_OF_DAY, 0)
+        newCal.set(Calendar.MINUTE, 0)
+        newCal.set(Calendar.SECOND, 0)
+        newCal.set(Calendar.MILLISECOND, 0)
+        return MDate(newCal, locale)
+    }
+
     private fun add(field: Int, value: Int): MDate {
         val newCal = calendar.clone() as Calendar
         newCal.add(field, value)
@@ -292,6 +306,11 @@ class MDate(val calendar: Calendar = Calendar.getInstance(), private val locale:
         fun Builder(): MDateBuilder {
             return MDateBuilder(Locale.getDefault())
         }
+    }
+
+    override fun compareTo(other: MDate): Int {
+        val result = ((this.calendar.timeInMillis - other.calendar.timeInMillis) / 1000).toInt()
+        return result
     }
 }
 


### PR DESCRIPTION
Added convenience methods

- Properties to access year, month, day, hour, minute, second without formatting
- RoundToDate method which sets hour, minute, second, millisecond to 0, allowing only date to be compared
- Comparable interface implemented, allowing comparison of dates with < > ==
- Updated MDate demo activity to show off the new features